### PR TITLE
fix dist build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["subdomains"]
+include = ["subdomains", "subdomains.templatetags"]
 namespaces = false
 
 [tool.black]


### PR DESCRIPTION
When I install django-subdomains2 from pypi , I notice that subdirectory templatetags is missing. So the pypi release is not very usefull. I just add "subdomains.templatetags" to include list. pip install from github is now correct.
